### PR TITLE
Default to duckdb.main and use updated API to create database

### DIFF
--- a/chakra_py/client.py
+++ b/chakra_py/client.py
@@ -152,7 +152,7 @@ class Chakra:
         [database_name, schema_name, _] = table_name.split(".")
         response = self._session.post(
             f"{BASE_URL}/api/v1/databases",
-            json={"name": database_name},
+            json={"name": database_name, "insert_database": True},
         )
         if response.status_code != 409:
             # only raise error if the database doesn't already exist
@@ -215,18 +215,6 @@ class Chakra:
             json={"sql": insert_sql, "parameters": parameters},
         )
         response.raise_for_status()
-
-    def _push_to_presigned_url(self, presigned_url: str, df: pd.DataFrame) -> None:
-        """
-        Upload a pandas DataFrame to S3 as a parquet file using a presigned URL.
-
-        Args:
-            df: The pandas DataFrame to upload
-            presigned_url: The S3 presigned URL for uploading
-
-        Returns:
-            bool: True if upload was successful, False otherwise
-        """
 
     def _request_presigned_url(self, file_name: str) -> dict:
         """Request a presigned URL for the upload."""
@@ -295,6 +283,15 @@ class Chakra:
         dedupe_on_append: bool = False,
         primary_key_columns: list[str] = [],
     ) -> None:
+        # Validate table name format
+        if table_name.count(".") != 0 and table_name.count(".") != 2:
+            raise ValueError(
+                "Table name must be either a simple table name (e.g., 'my_table') or fully qualified with database and schema (e.g., 'my_database.my_schema.my_table')"
+            )
+
+        if table_name.count(".") == 0:
+            table_name = f"duckdb.main.{table_name}"
+
         """Push data to a table."""
         if not self.token:
             raise ValueError("Authentication required")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,7 +135,10 @@ def test_data_push(mock_session, mock_requests_put, mock_uuid4):
     # 3. Verify the create database request
     create_db_call = mock_session.return_value.post.call_args_list[1]
     assert create_db_call[0][0] == "https://api.chakra.dev/api/v1/databases"
-    assert create_db_call[1]["json"] == {"name": "test_database"}
+    assert create_db_call[1]["json"] == {
+        "name": "test_database",
+        "insert_database": True,
+    }
 
     # 4. Verify the create schema request
     create_schema_call = mock_session.return_value.post.call_args_list[2]


### PR DESCRIPTION
1. if only the simple table name is specified, it'll default to `duckdb.main.[table_name]`
2. it only signals the backend to create the database entry in supabase's `databases` table via https://github.com/Chakra-Network/impossible-duckdb/pull/110

https://linear.app/chakra-labs/issue/CHA-1033/python-sdk-fixes